### PR TITLE
Add `tini` to the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,4 +34,6 @@ RUN gpg --keyserver pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4
     rm /usr/local/bin/gosu.asc && \
     chmod +sx /usr/local/bin/gosu
 
+# Use tini by default
+ENTRYPOINT ["/usr/bin/tini", "--"]
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,18 @@ RUN apt-get install -y curl gawk wget jq && \
     pip install awscli
 #      easy_install --upgrade pip && \
 
+# Include `https://github.com/krallin/tini`.
+# Newer versions of Docker (v1.13+) include `tini` out of the box using the
+# `--init` flag for `docker run` command
+# (https://docs.docker.com/engine/reference/commandline/run/#options).
+ARG TINI_VERSION=v0.18.0
+RUN gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 && \
+    curl -o /usr/bin/tini -sSL "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini" && \
+    curl -o /usr/bin/tini.asc -sSL "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini.asc" && \
+    gpg --verify /usr/bin/tini.asc && \
+    rm /usr/bin/tini.asc && \
+    chmod +x /usr/bin/tini
+
 RUN gpg --keyserver pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && \
     curl -o /usr/local/bin/gosu -sSL "https://github.com/tianon/gosu/releases/download/1.10/gosu-$(dpkg --print-architecture)" && \
     curl -o /usr/local/bin/gosu.asc -sSL "https://github.com/tianon/gosu/releases/download/1.10/gosu-$(dpkg --print-architecture).asc" && \

--- a/test.sh
+++ b/test.sh
@@ -9,3 +9,6 @@ docker run --rm ${IMAGE_NAME} bash -c '\
   useradd dummy_user; \
   su dummy_user -c "gosu root ls -la /root"; \
 '
+
+docker run --rm ${IMAGE_NAME} tini --version | \
+  grep -q '^tini version 0.18.0 - git.fec3683$'


### PR DESCRIPTION
Tini is a very simple `init` implementation.

Starting Docker 1.13 or greater, Tini is included in Docker itself.
This includes all versions of Docker CE. To enable Tini, just pass the
`--init` flag to `docker run`
(https://docs.docker.com/engine/reference/commandline/run/).